### PR TITLE
UT: Fix Coordinator Crash

### DIFF
--- a/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
+++ b/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
@@ -1056,7 +1056,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "Christoph Krey";
 				TargetAttributes = {
 					8404875D1C51212600569C79 = {
@@ -1086,10 +1086,9 @@
 			};
 			buildConfigurationList = 846191251883E56800101409 /* Build configuration list for PBXProject "MQTTClient" */;
 			compatibilityVersion = "Xcode 6.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -1764,6 +1763,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1817,6 +1817,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1859,7 +1860,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/MQTTFramework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1891,7 +1892,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/MQTTFramework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";

--- a/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
+++ b/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
@@ -1744,6 +1744,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1772,6 +1773,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1791,6 +1793,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -1798,6 +1801,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1826,6 +1830,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1839,6 +1844,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};
@@ -1846,6 +1852,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0AFA64F3A9AF8A328C843D5D /* Pods-MQTTClientiOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1877,6 +1884,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E1FA90F87F51C9D0FFFB8E7D /* Pods-MQTTClientiOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1909,6 +1917,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1FD1750F6ADDC84BEEC9C779 /* Pods-MQTTClientmacOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1942,6 +1951,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9CCB29D63B591010757C4A88 /* Pods-MQTTClientmacOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1976,6 +1986,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0F0C55D19D5DC409A7A95170 /* Pods-MQTTClienttvOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -2006,6 +2017,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4182CA8554A2D7614F23602A /* Pods-MQTTClienttvOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "";

--- a/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClientiOS.xcscheme
+++ b/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClientiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClientmacOS.xcscheme
+++ b/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClientmacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClienttvOS.xcscheme
+++ b/MQTTClient/MQTTClient.xcodeproj/xcshareddata/xcschemes/MQTTClienttvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MQTTClient/MQTTClient/MQTTCoreDataPersistence.h
+++ b/MQTTClient/MQTTClient/MQTTCoreDataPersistence.h
@@ -10,12 +10,30 @@
 #import <CoreData/CoreData.h>
 #import "MQTTPersistence.h"
 
-@interface MQTTCoreDataPersistence : NSObject <MQTTPersistence>
+@interface MQTTCoreDataFlow : NSObject <MQTTFlow>
+- (MQTTCoreDataFlow *)initWithContext:(NSManagedObjectContext *)context andObject:(id<MQTTFlow>)object;
+@property NSManagedObjectContext *context;
+@property id<MQTTFlow> object;
+@end
 
+@interface MQTTCoreDataPersistence : NSObject <MQTTPersistence>
+- (NSPersistentStoreCoordinator *)createPersistentStoreCoordinator;
+- (NSManagedObjectContext *)managedObjectContext;
+- (NSArray *)allFlowsforClientId:(NSString *)clientId;
+- (void)sync;
+- (void)deleteAllFlowsForClientId:(NSString *)clientId;
+- (void)deleteFlow:(MQTTCoreDataFlow *)flow;
+- (MQTTCoreDataFlow *)createFlowforClientId:(NSString *)clientId
+                               incomingFlag:(BOOL)incomingFlag
+                                  messageId:(UInt16)messageId;
+- (MQTTCoreDataFlow *)internalFlowForClientId:(NSString *)clientId
+                                 incomingFlag:(BOOL)incomingFlag
+                                    messageId:(UInt16)messageId;
+
+- (MQTTCoreDataFlow *)flowforClientId:(NSString *)clientId  incomingFlag:(BOOL)incomingFlag messageId:(UInt16)messageId;
+- (void)internalSync;
 @end
 
 @interface MQTTFlow : NSManagedObject <MQTTFlow>
 @end
 
-@interface MQTTCoreDataFlow : NSObject <MQTTFlow>
-@end

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -13,6 +13,7 @@
 #import "MQTTMessage.h"
 #import "MQTTCoreDataPersistence.h"
 #import "GCDTimer.h"
+#import <os/log.h>
 
 @class MQTTSSLSecurityPolicy;
 
@@ -49,7 +50,6 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
 @property (nonatomic) BOOL synchronDisconnect;
 
 @property (strong, nonatomic) MQTTSSLSecurityPolicy *securityPolicy;
-
 @end
 
 #define DUPLOOP 1.0
@@ -74,7 +74,6 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
     self.subscribeHandlers = [[NSMutableDictionary alloc] init];
     self.unsubscribeHandlers = [[NSMutableDictionary alloc] init];
     self.publishHandlers = [[NSMutableDictionary alloc] init];
-
     self.clientId = nil;
     self.userName = nil;
     self.password = nil;
@@ -802,7 +801,13 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
                                     self.effectiveKeepAlive = self.keepAliveInterval;
                                 }
 
+                                if (self.effectiveKeepAlive <= 0) {
+                                    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_INFO, "Ping Time Req modified %d", self.keepAliveInterval);
+                                    self.effectiveKeepAlive = self.keepAliveInterval;
+                                }
+
                                 if (self.effectiveKeepAlive > 0) {
+                                    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_INFO, "Ping Time Req %d", self.keepAliveInterval);
                                     self.keepAliveTimer = [GCDTimer scheduledTimerWithTimeInterval:self.effectiveKeepAlive
                                                                                            repeats:YES
                                                                                              queue:self.queue

--- a/MQTTClient/MQTTClientTests/MQTTCoreDataPersistenceTests.m
+++ b/MQTTClient/MQTTClientTests/MQTTCoreDataPersistenceTests.m
@@ -43,4 +43,17 @@
     XCTAssertEqual(store.type, NSInMemoryStoreType);
 }
 
+- (void)testNilCoordinator {
+    MQTTCoreDataPersistence *persistence = [[MQTTCoreDataPersistence alloc] init];
+    [persistence managedObjectContext];
+    [persistence createPersistentStoreCoordinator];
+    [persistence allFlowsforClientId:@"" incomingFlag:NO];
+    [persistence sync];
+    [persistence deleteAllFlowsForClientId:@""];
+    [persistence deleteFlow: [MQTTCoreDataFlow new] ];
+    [persistence createFlowforClientId:@"" incomingFlag:NO messageId:1];
+    [persistence internalFlowForClientId:@"" incomingFlag:NO messageId:1];
+    [persistence flowforClientId:@"" incomingFlag:NO messageId:1];
+}
+
 @end

--- a/MQTTClient/Pods/Pods.xcodeproj/project.pbxproj
+++ b/MQTTClient/Pods/Pods.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1320;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1121,7 +1121,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-MQTTClientiOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-MQTTClientiOS/Pods-MQTTClientiOS.modulemap";
@@ -1165,6 +1165,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1382,7 +1383,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket-iOS/SocketRocket-iOS-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/SocketRocket-iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SocketRocket-iOS/SocketRocket-iOS.modulemap";
 				PRODUCT_MODULE_NAME = SocketRocket;
@@ -1478,7 +1479,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket-iOS/SocketRocket-iOS-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/SocketRocket-iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SocketRocket-iOS/SocketRocket-iOS.modulemap";
 				PRODUCT_MODULE_NAME = SocketRocket;
@@ -1611,7 +1612,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-MQTTClientiOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-MQTTClientiOS/Pods-MQTTClientiOS.modulemap";
@@ -1656,6 +1657,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/MQTTClient/Pods/Target Support Files/SocketRocket-iOS/SocketRocket-iOS-umbrella.h
+++ b/MQTTClient/Pods/Target Support Files/SocketRocket-iOS/SocketRocket-iOS-umbrella.h
@@ -10,8 +10,8 @@
 #endif
 #endif
 
-#import "SocketRocket.h"
-#import "SRWebSocket.h"
+#import <SocketRocket/SocketRocket.h>
+#import <SocketRocket/SRWebSocket.h>
 
 FOUNDATION_EXPORT double SocketRocketVersionNumber;
 FOUNDATION_EXPORT const unsigned char SocketRocketVersionString[];


### PR DESCRIPTION
- See:
```
Fatal Exception: NSInvalidArgumentException
+entityForName: nil is not a legal NSPersistentStoreCoordinator for searching for entity name 'MQTTFlow'
__60-[MQTTCoreDataPersistence allFlowsforClientId:incomingFlag:]_block_invoke
```

