### PR TITLE
iOS-2720: Add Privacy manifest to MQTT-Client-Framework

### DIFF
--- a/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
+++ b/MQTTClient/MQTTClient.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		5DB67F0529940196004388C8 /* MQTTWebsocketTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB67F0129940195004388C8 /* MQTTWebsocketTransport.m */; };
 		5DB67F0629940196004388C8 /* MQTTWebsocketTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB67F0129940195004388C8 /* MQTTWebsocketTransport.m */; };
 		5DB67F0729940196004388C8 /* MQTTWebsocketTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB67F0129940195004388C8 /* MQTTWebsocketTransport.m */; };
+		5DF96C942BC6DC5C002D389E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5DF96C932BC6DC5C002D389E /* PrivacyInfo.xcprivacy */; };
 		840715FA1BBE999700FBB3CB /* mosquitto.org.cer in Resources */ = {isa = PBXBuildFile; fileRef = 8482D3C91B49332700D81CC8 /* mosquitto.org.cer */; };
 		840715FD1BBE999700FBB3CB /* server.der in Resources */ = {isa = PBXBuildFile; fileRef = C21D3CA71B1ED2F40012DD2F /* server.der */; };
 		840716041BBE999700FBB3CB /* AltName.cer in Resources */ = {isa = PBXBuildFile; fileRef = 6BC7FE28E1F56DDCC029E7B9 /* AltName.cer */; };
@@ -286,6 +287,7 @@
 /* Begin PBXFileReference section */
 		2669136D34EA79F3C5A432C4 /* Pods_MQTTClientiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MQTTClientiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DB67F0129940195004388C8 /* MQTTWebsocketTransport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MQTTWebsocketTransport.m; sourceTree = "<group>"; };
+		5DF96C932BC6DC5C002D389E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		65D0432F97D0733EB857DF64 /* Pods_MQTTClientiOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MQTTClientiOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BC7F5C2E599BA5BD018C8AB /* foobar.com.cer */ = {isa = PBXFileReference; lastKnownFileType = file.cer; path = foobar.com.cer; sourceTree = "<group>"; };
 		6BC7FE28E1F56DDCC029E7B9 /* AltName.cer */ = {isa = PBXFileReference; lastKnownFileType = file.cer; path = AltName.cer; sourceTree = "<group>"; };
@@ -594,6 +596,7 @@
 				846191301883E56800101409 /* Supporting Files */,
 				C701E3361FB0A70600B0CEB5 /* GCDTimer.h */,
 				C701E3371FB0A70600B0CEB5 /* GCDTimer.m */,
+				5DF96C932BC6DC5C002D389E /* PrivacyInfo.xcprivacy */,
 			);
 			path = MQTTClient;
 			sourceTree = "<group>";
@@ -1091,6 +1094,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5DF96C942BC6DC5C002D389E /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MQTTClient/MQTTClient/PrivacyInfo.xcprivacy
+++ b/MQTTClient/MQTTClient/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/MQTTClient/MQTTFramework/Info.plist
+++ b/MQTTClient/MQTTFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.2</string>
+	<string>0.17.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "MQTTClient",
-            path: "MQTTClient/MQTTClient"
+            path: "MQTTClient/MQTTClient",
+            resources: [.process("PrivacyInfo.xcprivacy")]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -173,6 +173,5 @@ This project was originally written by [Christoph Krey](https://github.com/ckrey
 - Create a new release candidate on [GitHub releases](https://github.com/qustodio/MQTT-Client-Framework/releases): `0.XX.XX`, For example: `0.15.7`.
 - Ensure you have permissions to S3.
 - Go to path: `cd MQTTClient`.
-- Finally, run the following command: `./scripts/build_xcframework.sh -v <verison> -s <URL from s3>`, For example: `./scripts/build_xcframework.sh -v 0.15.7 -s s3://aws.com/artifacts`.
-- Uplaod manually the zcframework zip file from `.tmp/archive/MQTTCLIENT-0.XX.XX.xcframework.zip`.
+- Finally, run the following command: `./scripts/build_xcframework.sh -v <verison> -s <URL from s3>`, For example: `./scripts/build_xcframework.sh -v 0.15.7 -s s3://static-dev.qustodio.com/artifacts/ios/MQTT-Client/`.
 


### PR DESCRIPTION
- Add Privacy Accessed API Type: Disk Space,  with reason: `85F4.1`. As
  the device is only printing a log using this information.
- Add PrivacyInfo.xcprivacy in Package.swift file.
- Bump version to 0.17.0.
